### PR TITLE
feat: map widget with messenger

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 yarn lint --no-cache

--- a/src/components/map/scene/index.tsx
+++ b/src/components/map/scene/index.tsx
@@ -9,6 +9,7 @@ import type { IMapData, IMapDataTiles } from "@/models/gamedata/levels/index"
 import Tile from "./tile"
 
 interface IMapSceneProps {
+  activeTiles: readonly number[]
   mapData: IMapData
   onTileClick?: (
     // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
@@ -35,7 +36,7 @@ class MapScene extends React.PureComponent<IMapSceneProps> {
   }
 
   public render (): React.ReactNode {
-    const { mapData, onTileClick } = this.props
+    const { activeTiles, mapData, onTileClick } = this.props
     const { tiles, width, height } = mapData
 
     return (
@@ -64,6 +65,7 @@ class MapScene extends React.PureComponent<IMapSceneProps> {
                 xs={1}
               >
                 <Tile
+                  active={activeTiles.includes(index)}
                   tile={tile}
                 />
               </Grid>

--- a/src/components/map/scene/tile/index.tsx
+++ b/src/components/map/scene/tile/index.tsx
@@ -1,5 +1,8 @@
 import React from "react"
 
+import PlaceIcon from "@mui/icons-material/Place"
+import type { SxProps, Theme } from "@mui/material"
+import { alpha } from "@mui/material"
 import { grey } from "@mui/material/colors"
 import Tooltip from "@mui/material/Tooltip"
 import Typography from "@mui/material/Typography"
@@ -14,6 +17,7 @@ import { TileEnd, TileFlystart, TileReed, TileReedFloor, TileReedWall, TileStart
 import { TileUndefined } from "./tileUndefined"
 
 interface ITileProps {
+  active?: boolean
   tile: IMapDataTiles
 }
 
@@ -43,10 +47,27 @@ const tileElements = {
 } as Record<string, JSX.Element | undefined>
 
 class Tile extends React.PureComponent<ITileProps> {
+  private static readonly defaultProps = {
+    active: false
+  }
+
   public render (): React.ReactNode {
-    const { tile } = this.props
+    const { active, tile } = this.props
 
     const tileElement = tileElements[tile.tileKey] ?? <TileUndefined />
+
+    const activeIconStyles: SxProps<Theme> = theme => ({
+      backgroundColor: alpha(theme.palette.primary.light, +"0.5"),
+      bottom: 0,
+      color: "white",
+      height: "100%",
+      left: 0,
+      padding: "20%",
+      position: "absolute",
+      right: 0,
+      top: 0,
+      width: "100%"
+    })
 
     return (
       <TileInfoContext.Consumer>
@@ -90,11 +111,20 @@ class Tile extends React.PureComponent<ITileProps> {
 
           return (
             <Tooltip
+              PopperProps={{
+                sx: {
+                  pointerEvents: "none"
+                }
+              }}
               arrow
               placement="top"
               title={tooltipContent}
             >
-              {tileElement}
+              <div style={{ position: "relative" }}>
+                {tileElement}
+
+                {active ? <PlaceIcon sx={activeIconStyles} /> : null}
+              </div>
             </Tooltip>
           )
         }}

--- a/src/models/utils/messenger.ts
+++ b/src/models/utils/messenger.ts
@@ -1,0 +1,195 @@
+/* eslint-disable @typescript-eslint/prefer-readonly-parameter-types */
+import { useEffect } from "react"
+
+const DEBUG = true as boolean
+
+let messengerName: string
+messengerName = ""
+
+if (typeof window !== "undefined") {
+  messengerName = location.host
+}
+
+// eslint-disable-next-line @typescript-eslint/no-type-alias
+export type Message<T extends string = string, D = undefined> = D extends undefined ? BaseMessage<T> : PayloadMessage<T, D>
+
+interface BaseMessage<T extends string = string> {
+  readonly id?: number | string
+  readonly type: T
+}
+
+export interface PayloadMessage<T extends string = string, D = never>
+  extends BaseMessage<T> {
+  readonly data: D
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+interface Messenger {
+  addEventListener: ((
+    type: string,
+    callback: EventListenerOrEventListenerObject,
+  ) => void) & (<M extends Message>(
+    type: string,
+    callback: ((ev: MessengerEvent<M>) => void) | null,
+  ) => void)
+  removeEventListener: ((
+    type: string,
+    callback: EventListenerOrEventListenerObject,
+  ) => void) & (<M extends Message>(
+    type: string,
+    callback: ((ev: MessengerEvent<M>) => void) | null,
+  ) => void)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging, no-redeclare
+class Messenger extends EventTarget {}
+
+export class MessengerEvent<M extends Message = Message> extends Event {
+  public readonly source: MessageEvent["source"]
+
+  public readonly origin: MessageEvent["origin"]
+
+  public readonly message: M
+
+  public constructor (
+    params: Pick<
+    MessengerEvent<M>,
+    "message" | "origin" | "source" | "type"
+    >
+  ) {
+    super(params.type)
+    this.source = params.source
+    this.origin = params.origin
+    this.message = params.message
+  }
+
+  /**
+   * Handy method to reply to the message's source.
+   * @returns a promise which is the result of `sendMessage()`.
+   */
+  public async reply (message: Message): Promise<boolean> {
+    if (this.source) {
+      return sendMessage(this.source as Window, this.origin, message)
+    }
+
+    return Promise.resolve(false)
+  }
+}
+
+const messenger = new Messenger()
+
+if (typeof window !== "undefined") {
+  window.addEventListener("message", (event: MessageEvent<object>) => {
+    const { data, origin, source } = event
+
+    if ((Boolean(data)) && "type" in data && typeof data.type === "string") {
+      if (DEBUG) {
+        if (!isAckType(data.type)) {
+          log("received", data)
+        }
+      }
+
+      messenger.dispatchEvent(new MessengerEvent({
+        message: data as Message,
+        origin,
+        source,
+        type: data.type
+      }))
+    }
+  })
+}
+
+export function useMessage<M extends Message = Message> (
+  origin: string,
+  type: M["type"],
+  listener: (message: MessengerEvent<M>) => void
+): void {
+  useEffect(() => {
+    const handler: typeof listener = (message) => {
+      if (isAckType(message.type)) {
+        return
+      }
+
+      if (origin === "*" || message.origin === origin) {
+        // we assume that the received message always has an id,
+        // since we generate one if it's missing when sending
+        const id = message.message.id! // eslint-disable-line @typescript-eslint/no-non-null-assertion
+
+        message.reply({ type: getAckType(id) }).catch((e) => {
+          log("Error:", e)
+        })
+
+        // processing messages received from outside can be error-prone, so we wrap the listener in a try-catch
+        try {
+          listener(message)
+        } catch (e) {
+          log("Error:", e)
+        }
+      }
+    }
+    messenger.addEventListener(type, handler)
+    return () => {
+      messenger.removeEventListener(type, handler)
+    }
+  }, [type, origin, listener])
+}
+
+export async function sendMessage<M extends Message> (
+  target: Pick<Window, "postMessage">,
+  origin: string,
+  message: M,
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+  timeout = 500
+): Promise<boolean> {
+  const messageToSend: Message & { id: NonNullable<Message["id"]> } = {
+    id: message.id ?? defaultIdGenerator(),
+    ...message
+  }
+
+  if (DEBUG) {
+    if (!isAckType(messageToSend.type)) {
+      log("sending", messageToSend)
+    }
+  }
+
+  const eventType = getAckType(messageToSend.id)
+
+  return new Promise<boolean>((resolve) => {
+    target.postMessage(messageToSend, origin)
+
+    const handler = (): void => {
+      messenger.removeEventListener(eventType, handler)
+      resolve(true)
+    }
+
+    if (timeout > +"0") {
+      window.setTimeout(() => {
+        messenger.removeEventListener(eventType, handler)
+        resolve(false)
+      }, timeout)
+    }
+
+    messenger.removeEventListener(eventType, handler)
+  })
+}
+
+function getAckType (id: NonNullable<Message["id"]>): string {
+  return `ack:${id}`
+}
+
+function isAckType (type: string): boolean {
+  return type.startsWith("ack:")
+}
+
+function defaultIdGenerator (): NonNullable<Message["id"]> {
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+  return Math.random().toString(36).slice(2, 6)
+}
+
+export function setMessengerName (name: string): void {
+  messengerName = name
+}
+
+function log (...args: unknown[]): void {
+  console.log(`[Msg:${messengerName}]`, ...args)
+}

--- a/src/pages/widget/map/[stageId]/adapter.tsx
+++ b/src/pages/widget/map/[stageId]/adapter.tsx
@@ -1,0 +1,24 @@
+import type { IMapData } from "../../../../models/gamedata/levels"
+import { useMessage } from "../../../../models/utils/messenger"
+
+import type { SetMapStateMessage } from "./connection"
+
+interface MapSceneWidgetAdapterProps {
+  mapData: IMapData
+  setActiveTiles: (activeTiles: readonly number[]) => void
+}
+
+/** The adapter component is for being able to use hooks. */
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+export function MapSceneWidgetAdapter ({ mapData, setActiveTiles }: Readonly<MapSceneWidgetAdapterProps>): null {
+  useMessage<SetMapStateMessage>("*", "setMapState", (e): void => {
+    const { activeTiles } = e.message.data
+
+    const indices = activeTiles.map(({ x, y }) => (mapData.height - y) * mapData.width + x)
+    const validIndices = indices.filter(tileIndex => tileIndex >= +"0" && tileIndex < mapData.tiles.length)
+
+    setActiveTiles(validIndices)
+  })
+
+  return null
+}

--- a/src/pages/widget/map/[stageId]/connection.ts
+++ b/src/pages/widget/map/[stageId]/connection.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-type-alias */
+import type { IMapDataTiles } from "../../../../models/gamedata/levels"
+import type { Message } from "../../../../models/utils/messenger"
+
+export type MapReadyMessage = Message<"mapReady">
+
+export type TileClickMessage = Message<
+"tileClick",
+{
+  index: number
+  width: number
+  height: number
+  maaLocation: [x: number, y: number]
+  tile: IMapDataTiles
+}
+>
+
+export type SetMapStateMessage = Message<
+"setMapState",
+{ activeTiles: { x: number; y: number }[] }
+>

--- a/src/pages/widget/map/[stageId]/scene.tsx
+++ b/src/pages/widget/map/[stageId]/scene.tsx
@@ -59,7 +59,7 @@ class MapSceneWidget extends React.PureComponent<MapSceneWidgetProps> {
             mapData={mapData}
             onTileClick={(_event, tile, index, width, height): void => {
               const x = index % width
-              const y = height - Math.ceil(index / width)
+              const y = height - Math.floor(index / width)
               console.log(`tileClick ${tile.tileKey}-maa-coordinate-${x}-${y}`)
 
               const postMessage = {


### PR DESCRIPTION
#1 

作业站那边我 push 到 dev 了，可以拉下来测试一下，设置好这里的地址：

https://github.com/MaaAssistantArknights/maa-copilot-frontend/blob/152f26a083b7f1f80a8abb5785afd59c1e0dedbd/src/components/editor/floatingMap/connection.ts#L4-L7

然后打开作业编辑器随便选择一个关卡就行，现在那边还没有 stageId 所以是写死的 main_00-01

`messenger.ts` 是两边共用的，代码差不多，这边的为了适应 eslint 做了一些类型上的修改，逻辑还是一样的
这个工具刚刚建成，后面可能会陆续完善